### PR TITLE
Refactor SchedulerCommunicator and complete iteration 1 sequence for Scheduler

### DIFF
--- a/src/SchedulerSubsystem/SchedulerDataGramCommunicator.java
+++ b/src/SchedulerSubsystem/SchedulerDataGramCommunicator.java
@@ -14,7 +14,6 @@ import SharedResources.*;
 
 public class SchedulerDataGramCommunicator {
 
-   //private DatagramPacket sendPacket, receivePacket;
    private DatagramSocket schedulerSocket;
    private int sendPort;
 

--- a/src/SchedulerSubsystem/SchedulerSystem.java
+++ b/src/SchedulerSubsystem/SchedulerSystem.java
@@ -1,4 +1,7 @@
 package SchedulerSubsystem;
+
+import SharedResources.*;
+
 /**
  * @author Kevin Quach
  * 
@@ -7,19 +10,26 @@ package SchedulerSubsystem;
  *
  */
 public class SchedulerSystem {
-	private static final SchedulerDataGramCommunicator communicator = new SchedulerDataGramCommunicator();
+	private static final SchedulerDataGramCommunicator floorCommunicator = new SchedulerDataGramCommunicator(5000);
+	private static final SchedulerDataGramCommunicator elevatorCommunicator = new SchedulerDataGramCommunicator(6000, 5001);
 	
 	/** Iteration 1 sequence
 	 * 1. floor reads events from file
 	 * 2. floor sends inputs to scheduler
 	 * 3. elevator makes calls to scheduler? ignore this
-	 * 4. scheduler sends data back to elevator //TODO
+	 * 4. scheduler sends data back to elevator
 	 * 5. elevator sends data back to scheduler
 	 * 6. scheduler sends data back to floor
 	 * 7. done
 	 */
 	public static void main(String[] args) {
-		communicator.receiveAndEcho();
+		FloorDataMessageSerializable msg = floorCommunicator.receive();
+		elevatorCommunicator.send(msg);
+		msg = elevatorCommunicator.receive(); //technically, elevator subsystem could talk to port 5000 and floorCommunicator could be used here instead of 5001 and elevatorCommunicator
+		floorCommunicator.send(msg);
+
+		floorCommunicator.closeSocket();
+		elevatorCommunicator.closeSocket();
 	}
 
 }


### PR DESCRIPTION
Communicators send and receive to a side of a subsystem to reduce the number of fields and messages passed between objects required to otherwise communicate only in one direction (eg. Floor to Elevator or Elevator to Floor). In the future, threads will be used to individually listen, and another thread to send. This likely requires #7 to be merged to function, along with Elevator's communication to be implemented.

Note that this still relies on the assumption that all subsystems are running on the same computer; which will need to be changed.